### PR TITLE
Create default universal relative search method

### DIFF
--- a/src/Api/Search/Relative.php
+++ b/src/Api/Search/Relative.php
@@ -21,6 +21,47 @@ use Nexy\Graylog\Api\AbstractApi;
 final class Relative extends AbstractApi
 {
     /**
+     * @param string      $query
+     * @param int         $range
+     * @param int|null    $limit
+     * @param int|null    $offset
+     * @param string|null $filter
+     * @param array|null  $fields
+     * @param string|null $sort
+     * @param bool|null   $decorate
+     *
+     * @return array
+     */
+    public function fetch(string $query, int $range, int $limit = null, int $offset = null, string $filter = null, array $fields = null, string $sort = null, bool $decorate = null): array
+    {
+        $parameters = [
+            'query' => $query,
+            'range' => $range,
+        ];
+
+        if (null !== $limit) {
+            $parameters['limit'] = $limit;
+        }
+        if (null !== $offset) {
+            $parameters['offset'] = $offset;
+        }
+        if (null !== $filter) {
+            $parameters['filter'] = $filter;
+        }
+        if (null !== $fields) {
+            $parameters['fields'] = implode(',', $fields);
+        }
+        if (null !== $sort) {
+            $parameters['sort'] = $sort;
+        }
+        if (null !== $decorate) {
+            $parameters['decorate'] = $decorate;
+        }
+
+        return $this->get('/', $parameters);
+    }
+
+    /**
      * @param string      $field
      * @param string      $query
      * @param int         $range


### PR DESCRIPTION
Develop `fetch` method to be able to search Graylog messages using 

```
get /search/universal/relative
```